### PR TITLE
impliment reproducible option

### DIFF
--- a/estwrite.hlp
+++ b/estwrite.hlp
@@ -10,7 +10,7 @@ help for {hi:estwrite}
 {p 8 15 2}
 {cmdab:estwrite} [{it:namelist} {cmd:using}] {it:filename}
  [{cmd:,} {cmd:id(}{it:varname}{cmd:)} {cmd:alt} {cmd:estsave}
- {cmdab:r:eplace} {cmdab:a:ppend} ]
+ {cmdab:r:eplace} {cmdab:a:ppend}  {cmd:reproducible}]
 
 {p 8 15 2}
 {cmdab:estread} [{it:namelist} {cmd:using}] {it:filename}
@@ -124,6 +124,14 @@ or without the {cmd:alt} option may be combined in a single file. The
 with {cmd:id()} option (and the values of the ID variables have to
 coincide). Similarly, the {cmd:id()} option is not allowed if the file to
 append to was created without {cmd:id()} option.
+
+{p 4 8 2}{cmd:reproducible} causes {cmd:estwrite} to save a "reproducible"
+file that will not change if re-run. This can be beneficial when working with 
+systems that track file-changes (e.g., git or source code build-systems). 
+Typical estimate files include a creation timestamp, which makes them different 
+every time they are generated. Reproducible-generated files have a fixed 
+timestamp. For technical reasons, this option also forcibly enables the {it:alt} 
+option.
 
 {p 4 8 2}{cmd:describe} causes {cmd:estread} to display information on the
 contents of {it:filename} without importing the estimation sets.


### PR DESCRIPTION
Implements a `reproducible` option discussed in [#2]. Following your suggestion, I have the `reproducible` option turn-on the `alt` option so we don't have to parse an unknown format from Stata. I didn't update any versions/change dates (e.g., in `estwrite.ado`, `estwrite.hlp`, `estwrite.pkg`) as I wasn't sure your policy on all that.

Here's also a simple test script
```
sysuse auto
reg price mpg

tempfile temp1a temp1b temp2a temp2b

* Show typical usage is not reproducible
estwrite using `temp1a', replace
checksum `temp1a'
loc cs1a = r(checksum)
sleep 1000 //need to wait for a different timestamp
estwrite using `temp2a', replace
checksum `temp2a'
loc cs2a = r(checksum)
_assert `cs1a'!=`cs2a', msg("These should differ")

* Show new option changes this
estwrite using `temp1b', reproducible replace
checksum `temp1b'
loc cs1b = r(checksum)
sleep 1000
estwrite using `temp2b', reproducible replace
checksum `temp2b'
loc cs2b = r(checksum)
_assert `cs1b'==`cs2b', msg("These should not differ")
```

Let me know if you have any suggestions